### PR TITLE
Support bitwise AND comparison in ItemFlags analyzers and update version

### DIFF
--- a/Archipelago.MultiClient.Net.Analyzers/Archipelago.MultiClient.Net.Analyzers.Package/Archipelago.MultiClient.Net.Analyzers.Package.csproj
+++ b/Archipelago.MultiClient.Net.Analyzers/Archipelago.MultiClient.Net.Analyzers.Package/Archipelago.MultiClient.Net.Analyzers.Package.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <PackageId>Archipelago.MultiClient.Net.Analyzers</PackageId>
-    <PackageVersion>1.4.1</PackageVersion>
+    <PackageVersion>1.5.0</PackageVersion>
     <Authors>BadMagic</Authors>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Archipelago.MultiClient.Net.Analyzers/Archipelago.MultiClient.Net.Analyzers.Test/ItemFlagComparisonsTest.cs
+++ b/Archipelago.MultiClient.Net.Analyzers/Archipelago.MultiClient.Net.Analyzers.Test/ItemFlagComparisonsTest.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis.Testing;
+﻿using Archipelago.MultiClient.Net.Analyzers.Test.Util;
+using Microsoft.CodeAnalysis.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Threading.Tasks;
 using VerifyCS = Archipelago.MultiClient.Net.Analyzers.Test.CSharpCodeFixVerifier<
@@ -57,6 +58,29 @@ namespace Archipelago.MultiClient.Net.Analyzers.Test
                         {
                             ItemFlags i = ItemFlags.Advancement;
                             return i.HasFlag(ItemFlags.Advancement);
+                        }
+                    }
+                }
+                """;
+
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
+
+        [TestMethod]
+        public async Task VerifyBitwiseAndComparisonYieldsNoDiagnostic()
+        {
+            string test = """
+                using System;
+                using Archipelago.MultiClient.Net.Enums;
+
+                namespace MyClient
+                {
+                    class MyClass
+                    {
+                        public bool Test()
+                        {
+                            ItemFlags i = ItemFlags.Advancement;
+                            return (i & ItemFlags.Advancement) == ItemFlags.Advancement;
                         }
                     }
                 }
@@ -237,6 +261,54 @@ namespace Archipelago.MultiClient.Net.Analyzers.Test
         }
 
         [TestMethod]
+        public async Task VerifyFixLhsIsMemberAccess_Net35()
+        {
+            string test = """
+                using System;
+                using Archipelago.MultiClient.Net.Enums;
+
+                namespace MyClient
+                {
+                    class MyClass
+                    {
+                        public bool Test()
+                        {
+                            ItemFlags i = ItemFlags.Advancement;
+                            return {|#0:ItemFlags.Advancement == i|};
+                        }
+                    }
+                }
+                """;
+            string fixTest = """
+                using System;
+                using Archipelago.MultiClient.Net.Enums;
+
+                namespace MyClient
+                {
+                    class MyClass
+                    {
+                        public bool Test()
+                        {
+                            ItemFlags i = ItemFlags.Advancement;
+                            return (i & ItemFlags.Advancement) == ItemFlags.Advancement;
+                        }
+                    }
+                }
+                """;
+
+            var testConfig = new VerifyCS.Test
+            {
+                TestCode = test,
+                FixedCode = fixTest,
+                ReferenceAssemblies = ReferenceAssemblies.NetFramework.Net35.Default.WithMultiClient(),
+            };
+
+            DiagnosticResult expected = VerifyCS.Diagnostic("MULTICLIENT002").WithLocation(0);
+            testConfig.ExpectedDiagnostics.Add(expected);
+            await testConfig.RunAsync();
+        }
+
+        [TestMethod]
         public async Task VerifyFixRhsIsMemberAccess()
         {
             string test = """
@@ -274,6 +346,54 @@ namespace Archipelago.MultiClient.Net.Analyzers.Test
 
             DiagnosticResult expected = VerifyCS.Diagnostic("MULTICLIENT002").WithLocation(0);
             await VerifyCS.VerifyCodeFixAsync(test, expected, fixTest);
+        }
+
+        [TestMethod]
+        public async Task VerifyFixRhsIsMemberAccess_Net35()
+        {
+            string test = """
+                using System;
+                using Archipelago.MultiClient.Net.Enums;
+
+                namespace MyClient
+                {
+                    class MyClass
+                    {
+                        public bool Test()
+                        {
+                            ItemFlags i = ItemFlags.Advancement;
+                            return {|#0:i == ItemFlags.Advancement|};
+                        }
+                    }
+                }
+                """;
+            string fixTest = """
+                using System;
+                using Archipelago.MultiClient.Net.Enums;
+
+                namespace MyClient
+                {
+                    class MyClass
+                    {
+                        public bool Test()
+                        {
+                            ItemFlags i = ItemFlags.Advancement;
+                            return (i & ItemFlags.Advancement) == ItemFlags.Advancement;
+                        }
+                    }
+                }
+                """;
+
+            var testConfig = new VerifyCS.Test
+            {
+                TestCode = test,
+                FixedCode = fixTest,
+                ReferenceAssemblies = ReferenceAssemblies.NetFramework.Net35.Default.WithMultiClient()
+            };
+
+            DiagnosticResult expected = VerifyCS.Diagnostic("MULTICLIENT002").WithLocation(0);
+            testConfig.ExpectedDiagnostics.Add(expected);
+            await testConfig.RunAsync();
         }
     }
 }

--- a/Archipelago.MultiClient.Net.Analyzers/Archipelago.MultiClient.Net.Analyzers.Test/ItemFlagSwitchTest.cs
+++ b/Archipelago.MultiClient.Net.Analyzers/Archipelago.MultiClient.Net.Analyzers.Test/ItemFlagSwitchTest.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis.Testing;
+﻿using Archipelago.MultiClient.Net.Analyzers.Test.Util;
+using Microsoft.CodeAnalysis.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Threading.Tasks;
 using VerifyCS = Archipelago.MultiClient.Net.Analyzers.Test.CSharpCodeFixVerifier<
@@ -140,6 +141,36 @@ namespace Archipelago.MultiClient.Net.Analyzers.Test
                 """;
             DiagnosticResult expectedDiagnostic = VerifyCS.Diagnostic("MULTICLIENT003").WithLocation(0);
             await VerifyCS.VerifyAnalyzerAsync(test, expectedDiagnostic);
+        }
+
+        [TestMethod]
+        public async Task VerifyBitwiseComparisonInSwitchStatementYieldsNoDiagnostic()
+        {
+            string test = """
+                using System;
+                using Archipelago.MultiClient.Net.Enums;
+
+                namespace MyClient
+                {
+                    class MyClass
+                    {
+                        public bool Test()
+                        {
+                            ItemFlags i = ItemFlags.Advancement;
+                            switch (i)
+                            {
+                                case ItemFlags f when (f & ItemFlags.Advancement) == ItemFlags.Advancement:
+                                    return true;
+                                case ItemFlags f when (f & ItemFlags.Trap) == ItemFlags.Trap:
+                                    return true;
+                                default:
+                                    return false;
+                            }
+                        }
+                    }
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(test);
         }
 
         [TestMethod]
@@ -526,6 +557,188 @@ namespace Archipelago.MultiClient.Net.Analyzers.Test
             DiagnosticResult expected2 = VerifyCS.Diagnostic("MULTICLIENT003").WithLocation(1);
             DiagnosticResult expected3 = VerifyCS.Diagnostic("MULTICLIENT003").WithLocation(2);
             await VerifyCS.VerifyCodeFixAsync(test, [expected1, expected2, expected3], fixTest);
+        }
+
+        [TestMethod]
+        public async Task VerifyFixSingleItemFlagsInSwitchStatement_Net35()
+        {
+            string test = """
+                using System;
+                using Archipelago.MultiClient.Net.Enums;
+
+                namespace MyClient
+                {
+                    class MyClass
+                    {
+                        public bool Test()
+                        {
+                            ItemFlags i = ItemFlags.Advancement;
+                            switch (i)
+                            {
+                                {|#0:case ItemFlags.Advancement:|}
+                                    return true;
+                                default:
+                                    return false;
+                            }
+                        }
+                    }
+                }
+                """;
+            string fixTest = """
+                using System;
+                using Archipelago.MultiClient.Net.Enums;
+
+                namespace MyClient
+                {
+                    class MyClass
+                    {
+                        public bool Test()
+                        {
+                            ItemFlags i = ItemFlags.Advancement;
+                            switch (i)
+                            {
+                                case ItemFlags f when (f & ItemFlags.Advancement) == ItemFlags.Advancement:
+                                    return true;
+                                default:
+                                    return false;
+                            }
+                        }
+                    }
+                }
+                """;
+
+            var testConfig = new VerifyCS.Test
+            {
+                TestCode = test,
+                FixedCode = fixTest,
+                ReferenceAssemblies = ReferenceAssemblies.NetFramework.Net35.Default.WithMultiClient(),
+            };
+
+            DiagnosticResult expected = VerifyCS.Diagnostic("MULTICLIENT003").WithLocation(0);
+            testConfig.ExpectedDiagnostics.Add(expected);
+            await testConfig.RunAsync();
+        }
+
+        [TestMethod]
+        public async Task VerifyFixMultipleItemFlagsInSwitchStatement_Net35()
+        {
+            string test = """
+                using System;
+                using Archipelago.MultiClient.Net.Enums;
+
+                namespace MyClient
+                {
+                    class MyClass
+                    {
+                        public bool Test()
+                        {
+                            ItemFlags i = ItemFlags.Advancement;
+                            switch (i)
+                            {
+                                {|#0:case ItemFlags.Advancement:|}
+                                    return true;
+                                {|#1:case ItemFlags.Trap:|}
+                                    return false;
+                                default:
+                                    return false;
+                            }
+                        }
+                    }
+                }
+                """;
+            string fixTest = """
+                using System;
+                using Archipelago.MultiClient.Net.Enums;
+
+                namespace MyClient
+                {
+                    class MyClass
+                    {
+                        public bool Test()
+                        {
+                            ItemFlags i = ItemFlags.Advancement;
+                            switch (i)
+                            {
+                                case ItemFlags f when (f & ItemFlags.Advancement) == ItemFlags.Advancement:
+                                    return true;
+                                case ItemFlags f when (f & ItemFlags.Trap) == ItemFlags.Trap:
+                                    return false;
+                                default:
+                                    return false;
+                            }
+                        }
+                    }
+                }
+                """;
+
+            var testConfig = new VerifyCS.Test
+            {
+                TestCode = test,
+                FixedCode = fixTest,
+                ReferenceAssemblies = ReferenceAssemblies.NetFramework.Net35.Default.WithMultiClient(),
+            };
+
+            DiagnosticResult expected1 = VerifyCS.Diagnostic("MULTICLIENT003").WithLocation(0);
+            DiagnosticResult expected2 = VerifyCS.Diagnostic("MULTICLIENT003").WithLocation(1);
+            testConfig.ExpectedDiagnostics.Add(expected1);
+            testConfig.ExpectedDiagnostics.Add(expected2);
+            await testConfig.RunAsync();
+        }
+
+        [TestMethod]
+        public async Task VerifyFixItemFlagsInSwitchExpression_Net35()
+        {
+            string test = """
+                using System;
+                using Archipelago.MultiClient.Net.Enums;
+
+                namespace MyClient
+                {
+                    class MyClass
+                    {
+                        public bool Test()
+                        {
+                            ItemFlags i = ItemFlags.Advancement;
+                            return i switch
+                            {
+                                {|#0:ItemFlags.Advancement|} => true,
+                                _ => false
+                            };
+                        }
+                    }
+                }
+                """;
+            string fixTest = """
+                using System;
+                using Archipelago.MultiClient.Net.Enums;
+
+                namespace MyClient
+                {
+                    class MyClass
+                    {
+                        public bool Test()
+                        {
+                            ItemFlags i = ItemFlags.Advancement;
+                            return i switch
+                            {
+                                ItemFlags f when (f & ItemFlags.Advancement) == ItemFlags.Advancement => true,
+                                _ => false
+                            };
+                        }
+                    }
+                }
+                """;
+
+            var testConfig = new VerifyCS.Test
+            {
+                TestCode = test,
+                FixedCode = fixTest,
+                ReferenceAssemblies = ReferenceAssemblies.NetFramework.Net35.Default.WithMultiClient(),
+            };
+
+            DiagnosticResult expected = VerifyCS.Diagnostic("MULTICLIENT003").WithLocation(0);
+            testConfig.ExpectedDiagnostics.Add(expected);
+            await testConfig.RunAsync();
         }
     }
 }

--- a/Archipelago.MultiClient.Net.Analyzers/Archipelago.MultiClient.Net.Analyzers.Test/Util/ReferenceAssemblyBuilder.cs
+++ b/Archipelago.MultiClient.Net.Analyzers/Archipelago.MultiClient.Net.Analyzers.Test/Util/ReferenceAssemblyBuilder.cs
@@ -4,7 +4,11 @@ namespace Archipelago.MultiClient.Net.Analyzers.Test.Util
 {
     internal static class ReferenceAssemblyBuilder
     {
-        public static ReferenceAssemblies DefaultWithMultiClient => ReferenceAssemblies.Default
-            .AddPackages([new PackageIdentity("Archipelago.MultiClient.Net", "6.3.0")]);
+        public static ReferenceAssemblies DefaultWithMultiClient => ReferenceAssemblies.Default.WithMultiClient();
+
+        public static ReferenceAssemblies WithMultiClient(this ReferenceAssemblies referenceAssemblies)
+        {
+            return referenceAssemblies.AddPackages([new PackageIdentity("Archipelago.MultiClient.Net", "6.3.0")]);
+        }
     }
 }

--- a/Archipelago.MultiClient.Net.Analyzers/Archipelago.MultiClient.Net.Analyzers/Analyzers/ItemFlagsDiagnostics.cs
+++ b/Archipelago.MultiClient.Net.Analyzers/Archipelago.MultiClient.Net.Analyzers/Analyzers/ItemFlagsDiagnostics.cs
@@ -32,11 +32,27 @@ namespace Archipelago.MultiClient.Net.Analyzers.Analyzers
             context.RegisterSyntaxNodeAction(AnalyzeComparison, SyntaxKind.EqualsExpression);
         }
 
+        private static bool IsBitwiseAndExpression(ExpressionSyntax expr)
+        {
+            // Unwrap parentheses first
+            while (expr is ParenthesizedExpressionSyntax pes)
+            {
+                expr = pes.Expression;
+            }
+            return expr is BinaryExpressionSyntax { OperatorToken.RawKind: (int)SyntaxKind.AmpersandToken };
+        }
+
         private void AnalyzeComparison(SyntaxNodeAnalysisContext context)
         {
             BinaryExpressionSyntax syntax = (BinaryExpressionSyntax)context.Node;
             ExpressionSyntax lhs = syntax.Left;
             ExpressionSyntax rhs = syntax.Right;
+
+            // Skip if either side is a bitwise & expression
+            if (IsBitwiseAndExpression(lhs) || IsBitwiseAndExpression(rhs))
+            {
+                return;
+            }
 
             // we apply the diagnostic if we are comparing 2 itemflags.
             TypeInfo leftHandType = context.SemanticModel.GetTypeInfo(lhs, context.CancellationToken);

--- a/Archipelago.MultiClient.Net.Analyzers/Archipelago.MultiClient.Net.Analyzers/Fixes/ItemFlagsFixes.cs
+++ b/Archipelago.MultiClient.Net.Analyzers/Archipelago.MultiClient.Net.Analyzers/Fixes/ItemFlagsFixes.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using Archipelago.MultiClient.Net.Analyzers.Util;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
@@ -61,10 +62,9 @@ namespace Archipelago.MultiClient.Net.Analyzers.Fixes
             {
                 context.RegisterCodeFix(
                     CodeAction.Create(
-                        title: "Use HasFlag",
-                        createChangedDocument: c => UseHasFlagAsync(
+                        title: "Use flag comparison",
+                        createChangedDocument: c => UseFlagComparisonAsync(
                             document: context.Document,
-                            oldRoot: root,
                             comparison: comparison,
                             dynamicPart: rhs,
                             constPart: lhs,
@@ -79,10 +79,9 @@ namespace Archipelago.MultiClient.Net.Analyzers.Fixes
             {
                 context.RegisterCodeFix(
                     CodeAction.Create(
-                        title: "Use HasFlag",
-                        createChangedDocument: c => UseHasFlagAsync(
+                        title: "Use flag comparison",
+                        createChangedDocument: c => UseFlagComparisonAsync(
                             document: context.Document,
-                            oldRoot: root,
                             comparison: comparison,
                             dynamicPart: lhs,
                             constPart: rhs,
@@ -104,23 +103,23 @@ namespace Archipelago.MultiClient.Net.Analyzers.Fixes
             return false;
         }
 
-        private async Task<Document> UseHasFlagAsync(
+        private async Task<Document> UseFlagComparisonAsync(
             Document document,
-            SyntaxNode oldRoot,
             BinaryExpressionSyntax comparison,
             ExpressionSyntax dynamicPart,
             ExpressionSyntax constPart,
             CancellationToken cancellationToken)
         {
             DocumentEditor editor = await DocumentEditor.CreateAsync(document, cancellationToken);
+            Compilation? compilation = await document.Project.GetCompilationAsync(cancellationToken);
 
-            SyntaxNode hasFlagAccess = editor.Generator.MemberAccessExpression(dynamicPart, "HasFlag");
-            SyntaxNode hasFlagCall = editor.Generator.InvocationExpression(hasFlagAccess, constPart);
+            ExpressionSyntax newExpression = ArchipelagoSyntaxFactory.CreateFlagComparison(
+                compilation,
+                dynamicPart,
+                constPart);
 
-            editor.ReplaceNode(comparison, hasFlagCall.WithTriviaFrom(comparison));
-
-            Document newDoc = editor.GetChangedDocument();
-            return newDoc;
+            editor.ReplaceNode(comparison, newExpression.WithTriviaFrom(comparison));
+            return editor.GetChangedDocument();
         }
     }
 }

--- a/Archipelago.MultiClient.Net.Analyzers/Archipelago.MultiClient.Net.Analyzers/Fixes/ItemFlagsInSwitchFixes.cs
+++ b/Archipelago.MultiClient.Net.Analyzers/Archipelago.MultiClient.Net.Analyzers/Fixes/ItemFlagsInSwitchFixes.cs
@@ -54,8 +54,8 @@ namespace Archipelago.MultiClient.Net.Analyzers.Fixes
 
             context.RegisterCodeFix(
                 CodeAction.Create(
-                    title: "Convert case to use HasFlag",
-                    createChangedDocument: c => ConvertCaseToHasFlag(
+                    title: "Convert case to use flag comparison",
+                    createChangedDocument: c => ConvertCaseToFlagComparison(
                         document: context.Document,
                         caseLabel: caseLabel,
                         cancellationToken: c
@@ -79,8 +79,8 @@ namespace Archipelago.MultiClient.Net.Analyzers.Fixes
 
             context.RegisterCodeFix(
                 CodeAction.Create(
-                    title: "Convert pattern to use HasFlag",
-                    createChangedDocument: c => ConvertConstantPatternArmToHasFlag(
+                    title: "Convert pattern to use flag comparison",
+                    createChangedDocument: c => ConvertConstantPatternArmToFlagComparison(
                         document: context.Document,
                         arm: arm,
                         constPattern: constPattern,
@@ -93,7 +93,7 @@ namespace Archipelago.MultiClient.Net.Analyzers.Fixes
             return true;
         }
 
-        private async Task<Document> ConvertCaseToHasFlag(
+        private async Task<Document> ConvertCaseToFlagComparison(
             Document document,
             CaseSwitchLabelSyntax caseLabel,
             CancellationToken cancellationToken)
@@ -101,7 +101,7 @@ namespace Archipelago.MultiClient.Net.Analyzers.Fixes
             DocumentEditor editor = await DocumentEditor.CreateAsync(document, cancellationToken);
             string variableName = NameGenerator.GetUniqueVariableName("f", editor.SemanticModel, caseLabel.SpanStart);
 
-            var (pattern, whenClause) = RewriteConstantMemberAccessToPatternMatch(caseLabel.Value, variableName);
+            var (pattern, whenClause) = await RewriteConstantMemberAccessToPatternMatch(document, caseLabel.Value, variableName, cancellationToken);
             CasePatternSwitchLabelSyntax newCaseLabel = SyntaxFactory.CasePatternSwitchLabel(
                 pattern, whenClause, SyntaxFactory.Token(SyntaxKind.ColonToken));
 
@@ -111,7 +111,7 @@ namespace Archipelago.MultiClient.Net.Analyzers.Fixes
             return newDoc;
         }
 
-        private async Task<Document> ConvertConstantPatternArmToHasFlag(
+        private async Task<Document> ConvertConstantPatternArmToFlagComparison(
             Document document,
             SwitchExpressionArmSyntax arm,
             ConstantPatternSyntax constPattern,
@@ -120,7 +120,7 @@ namespace Archipelago.MultiClient.Net.Analyzers.Fixes
             DocumentEditor editor = await DocumentEditor.CreateAsync(document, cancellationToken);
             string variableName = NameGenerator.GetUniqueVariableName("f", editor.SemanticModel, constPattern.SpanStart);
 
-            var (pattern, whenClause) = RewriteConstantMemberAccessToPatternMatch(constPattern.Expression, variableName);
+            var (pattern, whenClause) = await RewriteConstantMemberAccessToPatternMatch(document, constPattern.Expression, variableName, cancellationToken);
 
             SwitchExpressionArmSyntax newArm = SyntaxFactory.SwitchExpressionArm(pattern, whenClause, arm.Expression);
             editor.ReplaceNode(arm, newArm);
@@ -129,7 +129,11 @@ namespace Archipelago.MultiClient.Net.Analyzers.Fixes
             return newDoc;
         }
 
-        private (PatternSyntax, WhenClauseSyntax) RewriteConstantMemberAccessToPatternMatch(ExpressionSyntax expr, string newVarName)
+        private async Task<(PatternSyntax, WhenClauseSyntax)> RewriteConstantMemberAccessToPatternMatch(
+            Document document,
+            ExpressionSyntax expr, 
+            string newVarName,
+            CancellationToken cancellationToken)
         {
             SingleVariableDesignationSyntax variableDesignation = SyntaxFactory.SingleVariableDesignation(SyntaxFactory.Identifier(newVarName));
             DeclarationPatternSyntax declPattern = SyntaxFactory.DeclarationPattern(
@@ -137,18 +141,13 @@ namespace Archipelago.MultiClient.Net.Analyzers.Fixes
                 variableDesignation
             );
 
-            WhenClauseSyntax whenClause = SyntaxFactory.WhenClause(
-                SyntaxFactory.InvocationExpression(
-                    SyntaxFactory.MemberAccessExpression(
-                        SyntaxKind.SimpleMemberAccessExpression,
-                        SyntaxFactory.IdentifierName(newVarName),
-                        SyntaxFactory.IdentifierName("HasFlag")
-                    ),
-                    SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList(SyntaxFactory.Argument(expr)))
-                )
-            );
+            Compilation? compilation = await document.Project.GetCompilationAsync(cancellationToken);
+            ExpressionSyntax comparison = ArchipelagoSyntaxFactory.CreateFlagComparison(
+                compilation,
+                SyntaxFactory.IdentifierName(newVarName),
+                expr);
 
-            return (declPattern, whenClause);
+            return (declPattern, SyntaxFactory.WhenClause(comparison));
         }
     }
 }

--- a/Archipelago.MultiClient.Net.Analyzers/Archipelago.MultiClient.Net.Analyzers/Util/ArchipelagoSyntaxFactory.cs
+++ b/Archipelago.MultiClient.Net.Analyzers/Archipelago.MultiClient.Net.Analyzers/Util/ArchipelagoSyntaxFactory.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using System.Collections.Generic;
@@ -32,6 +33,60 @@ namespace Archipelago.MultiClient.Net.Analyzers.Util
                 decl,
                 generator.Attribute("DataStorageProperty", attributeArgs)
             );
+        }
+
+        /// <summary>
+        /// Creates a bitwise comparison that works on any .NET version
+        /// </summary>
+        public static ExpressionSyntax CreateBitwiseFlagComparison(
+            ExpressionSyntax dynamicPart,
+            ExpressionSyntax constPart)
+        {
+            return BinaryExpression(
+                SyntaxKind.EqualsExpression,
+                ParenthesizedExpression(
+                    BinaryExpression(
+                        SyntaxKind.BitwiseAndExpression,
+                        dynamicPart,
+                        constPart
+                    )
+                ),
+                constPart
+            );
+        }
+
+        public static ExpressionSyntax CreateFlagComparison(
+            Compilation? compilation,
+            ExpressionSyntax dynamicPart,
+            ExpressionSyntax constPart)
+        {
+            if (compilation == null)
+            {
+                // Fallback to bitwise & when we can't determine compilation - works on any .NET version
+                return CreateBitwiseFlagComparison(dynamicPart, constPart);
+            }
+
+            // Check if Enum.HasFlag is available in the compilation
+            INamedTypeSymbol? enumType = compilation.GetTypeByMetadataName("System.Enum");
+            bool hasHasFlagMethod = enumType?.GetMembers("HasFlag").Any() ?? false;
+
+            if (hasHasFlagMethod)
+            {
+                // Use HasFlag when available
+                return InvocationExpression(
+                    MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        dynamicPart,
+                        IdentifierName("HasFlag")
+                    ),
+                    ArgumentList(SingletonSeparatedList(Argument(constPart)))
+                );
+            }
+            else
+            {
+                // Use bitwise & when HasFlag is not available
+                return CreateBitwiseFlagComparison(dynamicPart, constPart);
+            }
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -41,10 +41,12 @@ This warning is intended to prevent bugs when comparing `ItemFlags`. Because ite
 an item might have multiple flag values set, such as `ItemFlags.Advancement | ItemFlags.Trap`. In such scenarios,
 a comparison like `item.Flags == ItemFlags.Advancement` does not capture the programmer's intent ("is this item
 a progression item"). Instead, `HasFlag` should be used to perform the comparison. `ItemFlags.Filler` is exempt
-from this rule because it has the value 0 and `HasFlag(0)` always returns true.
+from this rule because it has the value 0 and `HasFlag(0)` always returns true. This analyzer also allows using
+bitwise AND (e.g. `(item.Flags & ItemFlags.Advancement) == ItemFlags.Advancement`) directly.
 
-This analyzer also offers a corresponding fix action "Use HasFlag" on offending comparisons that contain a constant
-on exactly one side of the comparison. These comparisons will be replaced with a matching `HasFlag` check.
+This analyzer also offers a corresponding fix action "Use flag comparison" on offending comparisons that contain a constant
+on exactly one side of the comparison. These comparisons will be replaced with a matching `HasFlag` check. On older versions
+of .NET where `HasFlag` does not exist, a comparison using bitwise AND will be generated instead.
 
 **Incorrect Code:**
 
@@ -64,10 +66,11 @@ return item.Flags.HasFlag(ItemFlags.Advancement);
 This warning is intended to prevent bugs when comparing `ItemFlags`. Because item classification is a flag,
 an item might have multiple flag values set, such as `ItemFlags.Advancement | ItemFlags.Trap`. In such scenarios,
 a switch statement does not capture the programmer's intent ("is this item a progression item") due to its use of
-direct comparisons. Instead, pattern matching case statements with `HasFlag` should be used to perform the comparison. 
+direct comparisons. Instead, pattern matching case statements with `HasFlag` should be used to perform the comparison.
 
-This analyzer also offers a corresponding fix action "Convert case to use HasFlag" on offending switch
+This analyzer also offers a corresponding fix action "Convert case to use flag comparison" on offending switch
 statements. These statements will be replaced with pattern matching case statements containing the matching `HasFlag` checks.
+On older versions of .NET where `HasFlag` does not exist, a comparison using bitwise AND will be generated instead.
 
 **Incorrect Code:**
 


### PR DESCRIPTION
Enhance the ItemFlags analyzers to support flag comparisons using bitwise AND. Update documentation and version to reflect these changes.

Resolves #1